### PR TITLE
[FIX] Remove space between content and layout 

### DIFF
--- a/lib/screens/widgets/set_row_display.dart
+++ b/lib/screens/widgets/set_row_display.dart
@@ -42,14 +42,16 @@ class SetRowDisplay extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.all(8.0),
             child: Text(
-                '${Helper.getWeightInCorrectUnit(selectedExercises[index].sets[setIndex].weight).toStringAsFixed(1)} ${Config.getUnitAbbreviation()}'),
+                '${Helper.getWeightInCorrectUnit(selectedExercises[index].sets[setIndex].weight).toStringAsFixed(1)} ${Config.getUnitAbbreviation()}',
+                textAlign: TextAlign.right),
           ),
         ),
         Expanded(
           flex: 4,
           child: Padding(
             padding: const EdgeInsets.all(8.0),
-            child: Text('${selectedExercises[index].sets[setIndex].reps} reps'),
+            child: Text('${selectedExercises[index].sets[setIndex].reps} reps',
+                textAlign: TextAlign.right),
           ),
         ),
       ],


### PR DESCRIPTION
### What's new
- Text alignment was added to row content for last children

This should fix #77 

### Screenshot
![Screenshot 2024-03-18 150550](https://github.com/my-gym-buddy/my-gym-buddy-flutter/assets/37549606/741bb61c-1d5c-4f54-9b71-cab9c35d0c9d)
